### PR TITLE
Save Problem Parameters with Pickle

### DIFF
--- a/discretenet/problem.py
+++ b/discretenet/problem.py
@@ -32,7 +32,7 @@ class Problem(ABC):
         pass
 
     @abstractmethod
-    def __init__(self, *args, **kwargs):
+    def __init__(self):
         """
         Generate a concrete Pyomo model of the problem
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,4 +7,4 @@ testpaths = tests
 [flake8]
 # 88 is the max allowed by Black for code, 90 gives room for comments
 max-line-length = 90
-ignore = E203
+ignore = E203,W503

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,4 @@ testpaths = tests
 [flake8]
 # 88 is the max allowed by Black for code, 90 gives room for comments
 max-line-length = 90
+ignore = E203


### PR DESCRIPTION
- Save problem parameters with Pickle rather than json, since their types can be arbitrary
- Fix division by zero errors in the generators
- Add a method for loading problem pickled parameters. This is somewhat ugly thanks to python inheritance.
- Have flake8 ignore E203 warnings, which conflict with black