### PR TITLE
Improvements for Generation on Clusters

### DIFF
--- a/discretenet/generator.py
+++ b/discretenet/generator.py
@@ -106,9 +106,10 @@ class Generator(Generic[T]):
         :param save: Whether to immediately save the generated instances. Folder is
             set by ``self.path_prefix``.
         :param save_params: Whether to save problem parameters as a pickle file. Allows
-            for re-instantiating the Problem instances at a later time.
+            for re-instantiating the Problem instances at a later time. Only applies
+            if ``save`` is true.
         :param save_features: Whether to save computed features as a json file. This
-            can be slow for large models.
+            can be slow for large models. Only applies if ``save`` is True.
         :return: A list of generated concrete ``Problem`` instances
         """
 

--- a/discretenet/problem.py
+++ b/discretenet/problem.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from functools import lru_cache
 import json
 from pathlib import Path
 import pickle
@@ -38,6 +37,8 @@ class Problem(ABC):
         """
         Generate a concrete Pyomo model of the problem
 
+        Subclasses must first call ``super().__init__()``
+
         By the end of initialization, the model must be stored in ``self.model``.
         The model objective must be stored in ``self.model.objective``.
 
@@ -47,7 +48,8 @@ class Problem(ABC):
         After initialization, the model is assumed to be immutable.
         """
 
-        pass
+        # Caching for the VCG
+        self.variable_constraint_graph = None
 
     @abstractmethod
     def get_name(self) -> str:
@@ -73,7 +75,6 @@ class Problem(ABC):
         """
         pass
 
-    @lru_cache(maxsize=None)
     def get_features(self) -> Dict[str, float]:
         """
         Return a dictionary of computed features for the problem instance
@@ -686,7 +687,6 @@ class Problem(ABC):
                 for idx in x:
                     yield x[idx]
 
-    @lru_cache(maxsize=None)
     def get_variable_constraint_graph(self) -> nx.Graph:
         """
         Construct a bipartite Variable Constraint Graph of the problem instance
@@ -735,6 +735,9 @@ class Problem(ABC):
 
         :return: A bipartite variable constraint graph
         """
+
+        if self.variable_constraint_graph is not None:
+            return self.variable_constraint_graph
 
         G = nx.Graph()
 
@@ -824,6 +827,8 @@ class Problem(ABC):
                     )
 
                 G.nodes[var.getname()]["obj_coeff"] = coeff * objective_multiplier
+
+        self.variable_constraint_graph = G
 
         return G
 

--- a/discretenet/problem.py
+++ b/discretenet/problem.py
@@ -49,7 +49,7 @@ class Problem(ABC):
         """
 
         # Caching for the VCG
-        self.variable_constraint_graph = None
+        self.__variable_constraint_graph = None
 
     @abstractmethod
     def get_name(self) -> str:
@@ -736,8 +736,8 @@ class Problem(ABC):
         :return: A bipartite variable constraint graph
         """
 
-        if self.variable_constraint_graph is not None:
-            return self.variable_constraint_graph
+        if self.__variable_constraint_graph is not None:
+            return self.__variable_constraint_graph
 
         G = nx.Graph()
 
@@ -828,7 +828,7 @@ class Problem(ABC):
 
                 G.nodes[var.getname()]["obj_coeff"] = coeff * objective_multiplier
 
-        self.variable_constraint_graph = G
+        self.__variable_constraint_graph = G
 
         return G
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
 black==20.8b1
 flake8==3.8.4
+importlib-resources==5.1.2
 joblib==1.0.1
 mypy-extensions==0.4.3
 networkx==2.5
 numpy==1.19.5
-osmnx==1.0.1
 Pyomo==5.7.3
 pytest==6.2.2
 scipy==1.5.4
+Shapely==1.7.1


### PR DESCRIPTION
- Remove unnecessary packages from requirements.txt, add in one that was missing
- Remove LRU cache decorator for vcg and features in favor of just storing the vcg as a private istance attribute
- Add the option for not returning instances from the parallel workers, which can save time on having to pickle them
- Add the option for verbose progress messages from joblib