### PR TITLE
Name Caching in VCG Generation

### DIFF
--- a/discretenet/problem.py
+++ b/discretenet/problem.py
@@ -4,8 +4,6 @@ from pathlib import Path
 import pickle
 from typing import Any, Dict, Generator, Union, Type, TypeVar
 
-import time
-
 from pyomo.core.base.constraint import IndexedConstraint, _GeneralConstraintData
 from pyomo.core.expr.current import identify_variables, decompose_term
 import pyomo.environ as pyo


### PR DESCRIPTION
- When computing the VCG, provide a name buffer to `.getname()` of variable and constraints. This speeds things up by well over 1000x
- Solve a minor bug in `Problem.get_features()` when the objective is nonlinear